### PR TITLE
fix: whats new page

### DIFF
--- a/component/layout/BlogPost/SectionRelated.jsx
+++ b/component/layout/BlogPost/SectionRelated.jsx
@@ -5,7 +5,7 @@ import moment from "moment";
 import styles from "./SectionRelated.module.scss";
 
 export default function SectionRelated({ title, posts }) {
-  posts.splice(3)
+
   return (
     <section className={`${styles.section} py-10 lg:py-20`}>
       <div className="container container--post">
@@ -20,7 +20,7 @@ export default function SectionRelated({ title, posts }) {
           </span>
         </div>
         <div className={styles.relatedList}>
-          {posts.length > 0 ? (
+          {posts?.length > 0 ? (
             posts.map((post) => (
               <div className={styles.relatedItem} key={post._id}>
                 <figure>

--- a/component/layout/SiteHeader/SiteHeader.jsx
+++ b/component/layout/SiteHeader/SiteHeader.jsx
@@ -65,10 +65,7 @@ export default function HomeSpotlight() {
       router.reload();
     }
   }
-  // const handleDropDown = () => {
-  //   // console.log("clicked");
-  //   setDropDown(!dropdown);
-  // };
+
   return (
     <header
       className={`${styles.header} ${menu ? "menu-open" : " "} w-full`}

--- a/pages/whats-new.js
+++ b/pages/whats-new.js
@@ -27,16 +27,16 @@ export async function getServerSideProps(context) {
     };
   } catch (err) {
     console.log("Error => ", err);
+
     return {
-      redirect: {
-        permanent: false,
-        destination: "/404"
+      props : {
+        blogs: []
       }
-    };
+    }
   }
 }
 
-export default function whatsNew(props) {
+export default function whatsNew({blogs}) {
   return (
     <>
       <Head>
@@ -44,9 +44,10 @@ export default function whatsNew(props) {
       </Head>
       <SiteHeader />
       <WhatsNewSpotlight />
-      <WhatsNewPosts blogs={props.blogs} />
+      {blogs?.length > 0 ? <WhatsNewPosts blogs={props.blogs} /> : null}
       <SectionSwag />
       <SiteFooter />
     </>
   );
 }
+

--- a/services/PostService.js
+++ b/services/PostService.js
@@ -332,8 +332,13 @@ async function getPostsByMultipleTags(tags, clickNo) {
       tags: tags,
       clickNo: clickNo
     }});
-    // console.log(data);
+    
+
+    console.log("Data", data);
+    
     return data;
+
+
   } catch (err) {
     console.log(err);
     throw err;


### PR DESCRIPTION
## Description
`/whats-new` page was displaying `/404` which also had issues. This fix performs null checks and handles the edge cases appropriately.

Problem: The issue was inside API Call of `getServerSideProps` in `pages/whats-new`. It was throwing an error, and on error the catch block was implemented to redirect instead of handling the error. 

Fixes (#285)

- The API Call still has issue, and I am unaware about the specifics of how this API Call is configured, so I have handled errors appropriately. 
- `getServerSideProps` now returns a null object, instead of redirection. 
- The Blog Posts component only renders when posts are available, i.e., Conditional Rendering. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings