### PR TITLE
fix: whats-new page (development)

### DIFF
--- a/pages/whats-new.js
+++ b/pages/whats-new.js
@@ -45,7 +45,7 @@ export default function whatsNew({blogs}) {
       </Head>
       <SiteHeader />
       <WhatsNewSpotlight />
-      { blogs?.length > 0 && <WhatsNewPosts blogs={props.blogs} />}
+      { blogs?.length > 0 && <WhatsNewPosts blogs={blogs} />}
       <SectionSwag />
       <SiteFooter />
     </>


### PR DESCRIPTION
## Description
`/whats-new` page was displaying `/404` which also had issues. This fix performs null checks and handles the edge cases appropriately.

Problem: The issue was inside API Call of `getServerSideProps` in `pages/whats-new`. It was throwing an error, and on error the catch block was implemented to redirect instead of handling the error. 

Fixes (#285)
- The API Call still has issue, and I am unaware about the specifics of how this API Call is configured, so I have handled errors appropriately.
- `getServerSideProps` now returns a null object, instead of redirection. 
- The Blog Posts component only renders when posts are available, i.e., Conditional Rendering. 

Revision of #298 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings