### PR TITLE
fix: Showing hand icon when hovered on "Terms and Conditions" and fixing typo

### DIFF
--- a/pages/signup.js
+++ b/pages/signup.js
@@ -460,7 +460,7 @@ export default function SignUp({ referer }) {
                           >
                             I agree to the{" "}
                             <a href="#" className="text-white cursor-pointer underline">
-                              terms and conditions
+                              Terms and Conditions
                             </a>
                           </label>
                         </div>


### PR DESCRIPTION
## Description

Removing class cursor pointer and applying only on "Terms and Conditions". Also fixing typo of  "Terms and Conditions"

Fixes
 #307 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1) Go to sign in page
2) After this fix hand icon will be visible when hovered on "Terms and Conditions"

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings