### PR TITLE
fix: user profile getting elongated

### DIFF
--- a/component/profile/ProfileDetails.jsx
+++ b/component/profile/ProfileDetails.jsx
@@ -28,10 +28,10 @@ export default function ProfileDetails({ userData, userCurrentLogin }) {
               {/* picture */}
               <div className="relative">
                 <div className="rounded-full h-24 w-24 bg-blue-200 overflow-hidden">
-                  <Image
+                  <img
                     src={userData?.avatar || '/images/dummy0.png' }
                     alt="avatar"
-                    className="rounded-full h-24 w-24"
+                    className="rounded-full max-h-24 max-w-24"
                     layout="fill"
                   />
                 </div>


### PR DESCRIPTION
# Pull Request Template

## Description

profile image in  profile page get elongated when length of name is up to 30 characters

Fixes #603 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings