### PR TITLE
#539 Fix: Remove ending comma

### DIFF
--- a/component/layout/BlogListing/Tags.jsx
+++ b/component/layout/BlogListing/Tags.jsx
@@ -37,7 +37,7 @@ export default function Tags({ _tags }) {
               {moretags.map((tag, ind) => (
                 <Link href={`/tag/${tag.name}`} key={ind}>
                   <a className="hover:text-blue-900">{`${tag.name}${
-                    ind !== moretags - 1 && ", "
+                    ind !== moretags.length - 1 ? ", " : " " 
                   }`}</a>
                 </Link>
               ))}


### PR DESCRIPTION
Remove ending comma

## Description

Removed ending comma in the tags list of blog

Issue #539 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

