### PR TITLE
fix: not showing date when there is no event

### DIFF
--- a/component/layout/SectionEvents/SectionEvents.jsx
+++ b/component/layout/SectionEvents/SectionEvents.jsx
@@ -29,7 +29,7 @@ export default function SectionEvents({ events }) {
               <h3>
                 <span>{events?.title}</span>
               </h3>
-              <p>{moment(events?.event_time).format("MMMM Do YYYY, h:mm a")}</p>
+              <p>{events?.event_time && moment(events?.event_time).format("MMMM Do YYYY, h:mm a")}</p>
             </figcaption>
           </figure>
         </div>


### PR DESCRIPTION
# Pull Request Template

## Description

fixed on home page today's date is showing in section event when there is not event

Fixes #739 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings