### PR TITLE
fix: profile page of other users returns 404 in the case of logged out users

### DIFF
--- a/pages/u/[username].js
+++ b/pages/u/[username].js
@@ -46,11 +46,11 @@ export async function getServerSideProps(context) {
         };
       }
     } else {
+      const data = await UserService.getUserByUsername(context.params.username);
       return {
-        redirect: {
-          permanent: false,
-          destination: "/404"
-        }
+         props : {
+            userData : data?.data
+         }
       };
     }
   } catch (err) {


### PR DESCRIPTION
# Pull Request Template

## Description

fixed profile page of other users returns 404 in the case of logged out users

Fixes #765  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings