### PR TITLE
fix: fixed deprecated warning in HomeSpotlight.moudule.css file

### DIFF
--- a/component/layout/HomeSpotlight/HomeSpotlight.module.scss
+++ b/component/layout/HomeSpotlight/HomeSpotlight.module.scss
@@ -144,8 +144,8 @@
     $random-x: random(1000000) * 0.0001vw;
     $random-offset: random_range(-100000, 100000) * 0.0001vw;
     $random-x-end: $random-x + $random-offset;
-    $random-x-end-yoyo: $random-x + ($random-offset / 2);
-    $random-yoyo-time: random_range(30000, 80000) / 100000;
+    $random-x-end-yoyo: $random-x + calc($random-offset / 2);
+    $random-yoyo-time: calc(random_range(30000, 80000) / 100000);
     $random-yoyo-y: $random-yoyo-time * 100vh;
     $random-scale: random(10000) * 0.0001;
     $fall-duration: random_range(10, 30) * 1s;


### PR DESCRIPTION
# Pull Request Template

## Description
fixed deprecated warning in HomeSpotlight.moudule.css file

Fixes #769 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings