### PR TITLE
fix: error toast on login after user verification

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -155,7 +155,7 @@ export default function Login({ referer, verify }) {
           // } else {
           //   router.push("/");
           // }
-          if (referer.split('/')[3] === "forgot-password" || referer.split('/')[3].includes("reset-password")) {
+          if (!referer || referer.split('/')[3] === "forgot-password" || referer.split('/')[3].includes("reset-password")) {
             router.push("/");
           } else {
             router.back();


### PR DESCRIPTION
The referer becomes undefined

# Pull Request Template

## Description

The referer becomes undefined in the case where the user tries to login just after verifying the email

Fixes #879 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings